### PR TITLE
Add gRPC setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,34 @@ This is main repository for the Mintter project.
 
 ![Deploy Frontend & Publish](https://github.com/mintterteam/mintter/workflows/Deploy%20Frontend%20&%20Publish/badge.svg?branch=master)
 
-## Getting Started
-
-### Nix
+## Prerequisites
 
 You need to have [Nix](https://nixos.org/nix) package manager installed on your
 machine to work with this repository.
 
 To setup Nix see [this](/docs/nix.md).
 
+## Getting Started
+
+Assuming you have the prerequisites:
+
+1. Clone the repo.
+2. Run `redo` to build everything.
+3. Run `yarn dev` to run the frontend development server.
+4. Run `go run ./backend/cmd/backend/` to run the backend.
+5. Access the frontend URL from the browser.
+
 ### gRPC
 
 We are using [gRPC](https://grpc.io) for communication between frontend and
 backend. Take a look inside `.proto` files [here](/proto).
+
+### Frontend vs. Backend
+
+Frontend is the NextJS web app. For production, we'll use `next export` to
+generate static assets and use it as an SPA. These static assets are going to be
+served from the backend.
+
+Backend is a long-running program that lives on user's local machine. It handles
+all the p2p networking, IPFS and Lightning Network stuff. It exposes the gRPC
+API for frontend to use.

--- a/frontend/www/pages/_app.tsx
+++ b/frontend/www/pages/_app.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic'
 
 import '../styles/index.css'
 import UserProvider from '../shared/userContext'
+import {RpcProvider, makeRpcClient} from '../shared/rpc'
 
 const NoSSR: React.FC = ({children}) => {
   return <React.Fragment>{children}</React.Fragment>
@@ -17,11 +18,13 @@ const Dynamic = dynamic(() => Promise.resolve(NoSSR), {ssr: false})
 export default function App({Component, pageProps, router}: AppProps) {
   return (
     <Dynamic>
-      <UserProvider>
-        <AnimatePresence exitBeforeEnter>
-          <Component {...pageProps} key={router.route} />
-        </AnimatePresence>
-      </UserProvider>
+      <RpcProvider value={makeRpcClient()}>
+        <UserProvider>
+          <AnimatePresence exitBeforeEnter>
+            <Component {...pageProps} key={router.route} />
+          </AnimatePresence>
+        </UserProvider>
+      </RpcProvider>
     </Dynamic>
   )
 }

--- a/frontend/www/pages/index.tsx
+++ b/frontend/www/pages/index.tsx
@@ -1,9 +1,41 @@
-import React from 'react'
+import React, {useContext, useState, useEffect} from 'react'
 import Link from '../components/link'
 import Seo from '../components/seo'
 import Container from '../components/container'
 import Layout from '../components/layout'
 import Heading from '../components/heading'
+import {RpcContext} from '../shared/rpc'
+import {GenSeedRequest} from '@mintter/proto/mintter_pb'
+
+const GrpcTest = () => {
+  const rpc = useContext(RpcContext)
+  const [data, setData] = useState<{mnemonic: String[]}>({mnemonic: []})
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const req = new GenSeedRequest()
+      req.setAezeedPassphrase('test')
+
+      try {
+        const resp = await rpc.accounts.genSeed(req)
+        setData({mnemonic: resp.getMnemonicList()})
+      } catch (err) {
+        throw err
+      }
+    }
+
+    fetchData()
+  })
+
+  return (
+    <React.Fragment>
+      <h4>Testing gRPC</h4>
+      <div>
+        <p>{data.mnemonic.join(' ')}</p>
+      </div>
+    </React.Fragment>
+  )
+}
 
 export default function Home() {
   return (
@@ -26,6 +58,8 @@ export default function Home() {
               App
             </Link>
           </div>
+
+          <GrpcTest />
         </div>
       </Container>
     </Layout>

--- a/frontend/www/shared/rpc.ts
+++ b/frontend/www/shared/rpc.ts
@@ -1,0 +1,16 @@
+import {createContext} from 'react'
+import {AccountsPromiseClient} from '@mintter/proto/mintter_grpc_web_pb'
+
+interface RpcContextInterface {
+  accounts: AccountsPromiseClient
+}
+
+export const makeRpcClient = (): RpcContextInterface => {
+  return {
+    accounts: new AccountsPromiseClient('http://localhost:55001'),
+  }
+}
+
+export const RpcContext = createContext<RpcContextInterface>(makeRpcClient())
+
+export const RpcProvider = RpcContext.Provider


### PR DESCRIPTION
This PR provides an example of how gRPC could be used on the frontend. It's definitely not the most optimal thing, but I think gives some idea. You can reset completely the changes under `frontend` dir and set this up however you feel more comfortable.

You should be able to run this branch by doing the following in the root of the repository:

1. Run `redo` to build everything.
2. Run `go run ./backend/cmd/mintterd/` to start the backend. 
3. Run `yarn dev` to run the frontend.

Check out `proto/mintter.proto` file. The backend returns fake response every time.
