### PR TITLE
Improve TextField

### DIFF
--- a/frontend/ui/src/text-field/text-field.stories.mdx
+++ b/frontend/ui/src/text-field/text-field.stories.mdx
@@ -27,7 +27,6 @@ Pass a `size` prop to the `TextField` component to change its size.
 ```jsx
 <TextField size="1" placeholder="Small" />
 <TextField size="2" placeholder="Medium" />
-<TextField size="3" placeholder="Large" />
 ```
 
 > The default `TextField` `size` is `2`.
@@ -77,6 +76,12 @@ your `TextField` has a label associated, its color will change accordingly.
 ```jsx
 <TextField
   type="password"
+  status="neutral"
+  defaultValue="p@$$w0Rd"
+  hint="Your password should be secure"
+/>
+<TextField
+  type="password"
   status="success"
   defaultValue="p@$$w0Rd"
   hint="Your password was changed successfuly"
@@ -93,6 +98,8 @@ your `TextField` has a label associated, its color will change accordingly.
   hint="Please enter a valid email"
 />
 ```
+
+> The default `TextField` `status` is `neutral`.
 
 ### Disabled
 
@@ -151,7 +158,7 @@ Combine `TextField` props to preview your component.
       type: 'select',
       name: 'size',
       label: 'Size',
-      options: ['1', '2', '3'],
+      options: ['1', '2'],
       defaultValue: '2',
     },
     {
@@ -165,8 +172,8 @@ Combine `TextField` props to preview your component.
       type: 'select',
       name: 'status',
       label: 'Status',
-      options: ['', 'success', 'warning', 'danger'],
-      defaultValue: '',
+      options: ['neutral', 'success', 'warning', 'danger'],
+      defaultValue: 'neutral',
     },
     {
       type: 'string',

--- a/frontend/ui/src/text-field/text-field.tsx
+++ b/frontend/ui/src/text-field/text-field.tsx
@@ -4,9 +4,30 @@ import {forwardRef, useLayoutEffect, useRef} from 'react'
 import mergeRefs from 'react-merge-refs'
 import {v4} from 'uuid'
 
-import {Box, BoxProps} from '../box'
+import {Box} from '../box'
 import {styled} from '../stitches.config'
 import {Text} from '../text'
+
+const InputContainer = styled(Box, {
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+
+  variants: {
+    size: {
+      1: {
+        gap: '$2',
+      },
+      2: {
+        gap: '$3',
+      },
+    },
+  },
+
+  defaultVariants: {
+    size: '2',
+  },
+})
 
 const Input = styled('input', {
   $$backgroundColor: '$colors$background-default',
@@ -55,17 +76,11 @@ const Input = styled('input', {
       1: {
         fontSize: '$2',
         lineHeight: '$1',
-        paddingHorizontal: '$4',
-        paddingVertical: '$3',
+        paddingHorizontal: '$3',
+        paddingVertical: '$2',
       },
       2: {
         fontSize: '$3',
-        lineHeight: '$2',
-        paddingHorizontal: '$4',
-        paddingVertical: '$3',
-      },
-      3: {
-        fontSize: '$4',
         lineHeight: '$2',
         paddingHorizontal: '$4',
         paddingVertical: '$3',
@@ -127,6 +142,10 @@ const TextFieldHint = styled(Text, {
       },
     },
   },
+
+  defaultVariants: {
+    status: 'neutral',
+  },
 })
 
 export const TextField = forwardRef<
@@ -134,7 +153,7 @@ export const TextField = forwardRef<
   React.ComponentProps<typeof Input> & {
     label?: string
     hint?: string
-    containerCss?: BoxProps['css']
+    containerCss?: React.ComponentProps<typeof InputContainer>['css']
   }
 >(
   (
@@ -152,19 +171,15 @@ export const TextField = forwardRef<
     return (
       // TODO: Fix types
       // @ts-ignore
-      <Box
-        // TODO: Fix types
-        // @ts-ignore
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '$2',
-          width: '100%',
-          ...containerCss,
-        }}
-      >
+      <InputContainer size={props.size} css={containerCss}>
         {label ? (
-          <Label.Root as={Text} htmlFor={id} css={{marginBottom: '$3'}}>
+          <Label.Root
+            as={Text}
+            htmlFor={id}
+            size={
+              props.size === '1' ? '2' : props.size === '2' ? '3' : undefined
+            }
+          >
             {label}
           </Label.Root>
         ) : null}
@@ -180,13 +195,14 @@ export const TextField = forwardRef<
         {hint ? (
           <TextFieldHint
             status={status}
-            size="2"
-            css={{marginHorizontal: '$2'}}
+            size={
+              props.size === '1' ? '1' : props.size === '2' ? '2' : undefined
+            }
           >
             {hint}
           </TextFieldHint>
         ) : null}
-      </Box>
+      </InputContainer>
     )
   },
 )


### PR DESCRIPTION
## Summary

This PR improves the `TextField` component by changing its gap, label and hint sizes according to the size prop as per [this task](https://www.notion.so/mintter/TextField-improvements-label-hint-spacing-relative-to-size-prop-0600da5352b3488b8d4e3d5fa32a99e4).