### PR TITLE
chore(tauri): disable bundle for dev builds

### DIFF
--- a/desktop/app/tauri.conf.json
+++ b/desktop/app/tauri.conf.json
@@ -10,8 +10,8 @@
   },
   "tauri": {
     "bundle": {
-      "active": false,
-      "targets": "all",
+      "active": true,
+      "targets": ["app", "msi", "appimage"],
       "identifier": "com.mintter.dev",
       "icon": [
         "icons/32x32.png",


### PR DESCRIPTION
Bundling the app seems to be unnecessary when building locally.
Disabling it reduces the build time quite considerably improving the feedback loop.