### PR TITLE
fix: make language selector visible

### DIFF
--- a/frontend/app/src/editor/code/code.tsx
+++ b/frontend/app/src/editor/code/code.tsx
@@ -40,9 +40,6 @@ const SelectorWrapper = styled('div', {
   right: 0,
   top: 0,
   transform: 'translate(8px, -8px)',
-  zIndex: 2,
-  opacity: 0,
-  transition: 'opacity 0.5s',
 })
 
 interface CodePluginProps {


### PR DESCRIPTION
The language selector had [`opacity: 0`](https://github.com/mintterteam/mintter/blob/e05f0c25c85d46c68ca74dcc6b3a1db7b7ecbbdb/frontend/app/src/editor/code/code.tsx#L44) set. This PR removes that.

closes #560