### PR TITLE
fix: strip space from heading when using md shortcut

### DIFF
--- a/frontend/app/src/editor/markdown-plugin.ts
+++ b/frontend/app/src/editor/markdown-plugin.ts
@@ -139,7 +139,7 @@ export const createMarkdownShortcutsPlugin = (): EditorPlugin => ({
           }
         }
 
-        // turn statement into
+        // turn Statement into Heading
         if (beforeText === '#') {
           const above = Editor.above(editor, {
             match: isStatement,
@@ -161,6 +161,7 @@ export const createMarkdownShortcutsPlugin = (): EditorPlugin => ({
                 {match: isParagraph},
               )
             })
+            return
           }
         }
       }


### PR DESCRIPTION
closes #355