### PR TITLE
fix: persist text color

### DIFF
--- a/frontend/app/src/client/v2/block-to-api.ts
+++ b/frontend/app/src/client/v2/block-to-api.ts
@@ -70,6 +70,10 @@ export function blockToApi(
       annotations.addSpan('code', null, start, end)
     }
 
+    if (leaf.color) {
+      annotations.addSpan('color', {color: leaf.color}, start, end)
+    }
+
     // inline block elements check
 
     if (leaf.type == 'image') {

--- a/frontend/app/src/client/v2/block-to-slate.ts
+++ b/frontend/app/src/client/v2/block-to-slate.ts
@@ -167,6 +167,11 @@ export function blockToSlate(blk: Block): FlowContent {
         // @ts-ignore
         leaf[l.type] = true
       }
+
+      if (l.type === 'color') {
+        // @ts-ignore
+        leaf['color'] = l.attributes.color
+      }
     })
 
     if (linkAnnotation) {

--- a/frontend/app/src/components/library/section-contacts.tsx
+++ b/frontend/app/src/components/library/section-contacts.tsx
@@ -46,7 +46,7 @@ function ContactListLoading() {
 
 export function ContactsSection() {
   const {status, data, refetch, fetchStatus} = useContacts()
-  console.log('Contacts', status, data, fetchStatus)
+  // console.log('Contacts', status, data, fetchStatus)
   let title = `Contacts (${data?.accounts?.length || 0})`
 
   return (
@@ -327,6 +327,6 @@ function ContactItem({contact}: ContactItemProps) {
 }
 
 function useContacts() {
-  console.log('useContacts!')
+  // console.log('useContacts!')
   return useQuery([queryKeys.GET_CONTACTS_LIST], () => listAccounts())
 }


### PR DESCRIPTION
text cooler was not correctly persisted when sent to the daemon. 

This fix is only relevant for users on macBooks with Touch Bar, as we currently don't expose text colours through UI