### PR TITLE
feat: add prompt on daemon crash

### DIFF
--- a/desktop/app/src/main.rs
+++ b/desktop/app/src/main.rs
@@ -73,6 +73,7 @@ fn main() {
     .invoke_handler(tauri::generate_handler![emit_all])
     .setup(|app| {
       daemon::start_daemon(
+        app.handle(),
         app.state::<daemon::Connection>(),
         app.state::<daemon::Flags>(),
       );


### PR DESCRIPTION
Use a native confirmation prompt, bc that won't be impacted by any frontend crashes