### PR TITLE
fix: add invisible drag handle to settings window

### DIFF
--- a/frontend/app/src/pages/settings.tsx
+++ b/frontend/app/src/pages/settings.tsx
@@ -25,17 +25,13 @@ export default function Settings({
   const auth = useInterpret(() => createAuthService(client, updateProfile))
   return (
     <div className="settings-wrapper">
+      <div className="drag-handle" data-tauri-drag-region></div>
       <TabsPrimitive.Root
         className="tabs"
         defaultValue="profile"
         orientation="vertical"
-        data-tauri-drag-region
       >
-        <TabsPrimitive.List
-          className="tabs-list"
-          aria-label="Manage your node"
-          data-tauri-drag-region
-        >
+        <TabsPrimitive.List className="tabs-list" aria-label="Manage your node">
           <TabsPrimitive.Trigger
             className="tab-trigger"
             value="profile"

--- a/frontend/app/src/styles/settings.scss
+++ b/frontend/app/src/styles/settings.scss
@@ -1,3 +1,6 @@
+@use 'mixins/platform';
+@use 'variables' as *;
+
 .settings-wrapper {
   position: fixed;
   inset: 0;
@@ -54,6 +57,13 @@
     &[data-state='inactive'] {
       display: none;
     }
+  }
+
+  .drag-handle {
+    position: fixed;
+    z-index: 999;
+    width: 100vw;
+    height: $darwin-title-bar-height;
   }
 }
 


### PR DESCRIPTION
Adds an invisible titlebar-sized drag handle to the top of the settings window so users can drag the window where they expect it to.